### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Docker Build and Push
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/degagne/docker-aws-cli/security/code-scanning/1](https://github.com/degagne/docker-aws-cli/security/code-scanning/1)

The best way to fix this issue is to add a `permissions` block to the workflow, specifying only the minimal set of permissions required. For this Docker build-and-push workflow, no steps appear to require write access to repository contents, issues, or pull requests. The only step that potentially interacts with the repository is the `actions/checkout@v4`, but this only needs read access. Therefore, we should add `permissions: contents: read` either at the root of the workflow (to apply to all jobs), or inside the job definition (`build-and-push-docker`). The recommended approach is to add it at the root so all future jobs inherit the restricted permissions unless otherwise required.

To implement the fix:
- Edit `.github/workflows/docker-ci.yml`
- Insert a root-level `permissions:` block after the workflow `name:` and before the `on:` key.
- The block should read:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
